### PR TITLE
Revert back afterRender schedule

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -3,7 +3,7 @@
 import $ from 'jquery';
 import Component from '@ember/component';
 import { getProperties, computed } from '@ember/object';
-import { once } from '@ember/runloop';
+import { once, scheduleOnce } from '@ember/runloop';
 import { warn } from '@ember/debug';
 import { assign as emAssign } from '@ember/polyfills';
 import { or } from '@ember/object/computed';
@@ -193,14 +193,15 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    this.set('registerAs', this);
+    scheduleOnce('afterRender', this, () => {
+      this.set('registerAs', this);
+      this
+        .set('_swiper', new Swiper(this.element, this._getOptions()))
+        .on('onSlideChangeEnd', this.slideChanged.bind(this))
+        .slideTo(this.get('currentSlide'));
 
-    this
-      .set('_swiper', new Swiper(this.element, this._getOptions()))
-      .on('onSlideChangeEnd', this.slideChanged.bind(this))
-      .slideTo(this.get('currentSlide'));
-
-    this.sendAction('afterSwiperInit', this);
+      this.sendAction('afterSwiperInit', this);
+    });
   },
 
   willDestroyElement() {


### PR DESCRIPTION
Removing this has caused the navigation on our components to break when defining an elementId as part of a next/prev button.  Basically, this works fine if you only have one component on the page, but if you have more than one you need to pass in a specific next/prev button. 

In that case, the afterRender is needed.