### PR TITLE
Add `data-` attributeBindings to swiper-slide components

### DIFF
--- a/addon/components/swiper-slide.js
+++ b/addon/components/swiper-slide.js
@@ -1,7 +1,25 @@
 import Component from '@ember/component';
 import layout from '../templates/components/swiper-slide';
 
+export const PERMITTED_DATA_ATTRIBUTES = [
+  'data-history',
+  'data-id',
+  'data-swiper-autoplay',
+  'data-swiper-parallax',
+  'data-swiper-parallax-x',
+  'data-swiper-parallax-y',
+  'data-swiper-parallax-scale',
+  'data-swiper-parallax-opacity',
+  'data-swiper-parallax-duration',
+  'data-background',
+  'data-src',
+  'data-srcset',
+  'data-swiper-zoom',
+  'data-hash'
+];
+
 export default Component.extend({
   layout,
+  attributeBindings: PERMITTED_DATA_ATTRIBUTES,
   classNames: ['swiper-slide']
 });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,8 @@ module.exports = function(defaults) {
     // Add options here
   });
 
+  app.import('vendor/ember/ember-template-compiler.js');
+
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/tests/integration/components/swiper-slide-test.js
+++ b/tests/integration/components/swiper-slide-test.js
@@ -2,6 +2,9 @@ import { find, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { camelize } from '@ember/string';
+import { PERMITTED_DATA_ATTRIBUTES } from 'ember-cli-swiper/components/swiper-slide';
+import { compileTemplate } from '@ember/template-compilation';
 
 module('Integration | Component | swiper slide', function(hooks) {
   setupRenderingTest(hooks);
@@ -30,5 +33,20 @@ module('Integration | Component | swiper slide', function(hooks) {
     await render(hbs`{{swiper-slide id="slide" class="foo bar"}}`);
     assert.ok(find('#slide').classList.contains('foo'));
     assert.ok(find('#slide').classList.contains('bar'));
+  });
+
+  test('whitelisted data attributes are added', async function(assert) {
+    for (let attr of PERMITTED_DATA_ATTRIBUTES) {
+      let innerAttr = attr.slice(attr.indexOf('-') + 1);
+
+      await render(compileTemplate(`{{swiper-slide id="slide" ${attr}="foo"}}`));
+
+      assert.equal(find('#slide').dataset[camelize(innerAttr)], 'foo');
+    }
+  });
+
+  test('non-whitelisted data attributes are not added', async function(assert) {
+    await render(hbs`{{swiper-slide id="slide" data-not-allowed="foo"}}`);
+    assert.notOk(find('#slide').dataset['not-allowed']);
   });
 });


### PR DESCRIPTION
I used all `data-` attributes mentioned in the [Swiper API docs](http://idangero.us/swiper/api/), plus `data-id` for more manual handling.